### PR TITLE
raise error when failed to open db connection

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ func main() {
 	}
 
 	db, err := contract.Open(cfg.Engine.Driver, cfg.Engine.DSN)
+	if err != nil {
+		log.Fatal("failed to open database connection due to: ", err.Error())
+	}
 
 	redis.ListenAndServe(cfg, db)
 }


### PR DESCRIPTION
We aren't noticed any errors even when failed to connect database. The process would continue to run. It would be better to notice such connection errors.